### PR TITLE
Fixed GCC 5.4.0 warnings

### DIFF
--- a/include/dip_matlab_interface.h
+++ b/include/dip_matlab_interface.h
@@ -28,6 +28,7 @@
 #include <cstring>
 #ifdef DIP__ENABLE_UNICODE
 #include <codecvt>
+#include <locale>
 #endif
 
 #include "mex.h"
@@ -117,7 +118,7 @@ inline bool IsMatlabStrides(
       return false;
    }
    if( sizes.size() == 1 ) {
-      if( strides[ 0 ] != telem ) {
+      if( strides[ 0 ] != static_cast< dip::sint >( telem )) {
          //mexPrintf( "IsMatlabStrides: 1D test failed\n" );
          return false;
       }
@@ -261,6 +262,8 @@ inline mxArray* CreateTensorShape( enum dip::Tensor::Shape shape ) {
       case dip::Tensor::Shape::LOWTRIANG_MATRIX:
          return mxCreateString( "lower triangular matrix" );
    }
+   
+   return NULL;
 }
 
 // Get the dip::Tensor::Shape value from a string mxArray
@@ -431,7 +434,7 @@ inline dip::BooleanArray GetProcessArray( mxArray const* mx, dip::uint nDims ) {
       }
       dip::BooleanArray out( nDims, false );
       for( auto ii : in ) {
-         DIP_THROW_IF( ( ii <= 0 ) || ( ii > nDims ), "Process array contains index out of range" );
+         DIP_THROW_IF( ( ii <= 0 ) || ( ii > static_cast< dip::sint >( nDims )), "Process array contains index out of range" );
          out[ ii - 1 ] = true;
       }
       return out;
@@ -874,7 +877,7 @@ class MatlabInterface : public dip::ExternalInterface {
          mxSetPropertyShared( out, 0, ndimsPropertyName, ndims );
          // Set TensorShape property
          if( img.TensorElements() > 1 ) {
-            mxArray* tshape;
+            mxArray* tshape=NULL;
             switch( img.TensorShape() ) {
                case dip::Tensor::Shape::COL_VECTOR:
                   tshape = CreateDouble2Vector( img.TensorElements(), 1 );
@@ -1007,7 +1010,7 @@ inline dip::Image GetImage( mxArray const* mx ) {
       }
       mxdata = mx;
       // Sizes
-      ndims = ndims = mxGetNumberOfDimensions( mxdata );
+      ndims = mxGetNumberOfDimensions( mxdata );
       psizes = mxGetDimensions( mxdata );
       if( ndims <= 2 ) {
          if( psizes[ 0 ] == 1 && psizes[ 1 ] == 1 ) {


### PR DESCRIPTION
I'm compiling with 5.4.0, and even though it's not supported by Matlab yet I thought it would be nice to clean up these warnings:

In file included from /home/wouter/src/diplib.remote/dipimage/@dip_image/percentile.cpp:23:0:
/home/wouter/src/diplib.remote/include/dip_matlab_interface.h: In function ‘bool dml::{anonymous}::IsMatlabStrides(const UnsignedArray&, dip::uint, const IntegerArray&, dip::sint)’:
/home/wouter/src/diplib.remote/include/dip_matlab_interface.h:120:24: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
       if( strides[ 0 ] != telem ) {
                        ^
In file included from /home/wouter/src/diplib.remote/dipimage/@dip_image/percentile.cpp:23:0:
/home/wouter/src/diplib.remote/include/dip_matlab_interface.h: In function ‘dip::BooleanArray dml::{anonymous}::GetProcessArray(const mxArray*, dip::uint)’:
/home/wouter/src/diplib.remote/include/dip_matlab_interface.h:434:39: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
          DIP_THROW_IF( ( ii <= 0 ) || ( ii > nDims ), "Process array contains index out of range" );
                                       ^
In file included from /home/wouter/src/diplib.remote/dipimage/@dip_image/percentile.cpp:23:0:
/home/wouter/src/diplib.remote/include/dip_matlab_interface.h: In function ‘mxArray* dml::{anonymous}::GetArrayUnicode(const String&)’:
/home/wouter/src/diplib.remote/include/dip_matlab_interface.h:699:28: error: ‘wstring_convert’ is not a member of ‘std’
    std::u16string u16str = std::wstring_convert< std::codecvt_utf8_utf16< char16_t >, char16_t >{}.from_bytes( in );
                            ^
/home/wouter/src/diplib.remote/include/dip_matlab_interface.h:699:85: error: expected primary-expression before ‘,’ token
    std::u16string u16str = std::wstring_convert< std::codecvt_utf8_utf16< char16_t >, char16_t >{}.from_bytes( in );
                                                                                     ^
/home/wouter/src/diplib.remote/include/dip_matlab_interface.h:699:99: error: expected ‘,’ or ‘;’ before ‘.’ token
    std::u16string u16str = std::wstring_convert< std::codecvt_utf8_utf16< char16_t >, char16_t >{}.from_bytes( in );
                                                                                                   ^
In file included from /home/wouter/src/diplib.remote/dipimage/@dip_image/percentile.cpp:23:0:
/home/wouter/src/diplib.remote/include/dip_matlab_interface.h: In function ‘dip::Image dml::{anonymous}::GetImage(const mxArray*)’:
/home/wouter/src/diplib.remote/include/dip_matlab_interface.h:1010:56: warning: operation on ‘ndims’ may be undefined [-Wsequence-point]
       ndims = ndims = mxGetNumberOfDimensions( mxdata );
                                                        ^
In file included from /home/wouter/src/diplib.remote/dipimage/@dip_image/percentile.cpp:23:0:
/home/wouter/src/diplib.remote/include/dip_matlab_interface.h: In function ‘mxArray* dml::{anonymous}::CreateTensorShape(dip::Tensor::Shape)’:
/home/wouter/src/diplib.remote/include/dip_matlab_interface.h:264:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^
CMakeFiles/MEX_percentile.dir/build.make:62: recipe for target 'CMakeFiles/MEX_percentile.dir/dipimage/@dip_image/percentile.cpp.o' failed
make[2]: *** [CMakeFiles/MEX_percentile.dir/dipimage/@dip_image/percentile.cpp.o] Error 1
CMakeFiles/Makefile2:291: recipe for target 'CMakeFiles/MEX_percentile.dir/all' failed
make[1]: *** [CMakeFiles/MEX_percentile.dir/all] Error 2
Makefile:138: recipe for target 'all' failed
make: *** [all] Error 2
