### PR TITLE
Error correction in usage of Function Measure

### DIFF
--- a/examples/pydip_examples.py
+++ b/examples/pydip_examples.py
@@ -112,7 +112,7 @@ dip.WriteCSV(m,'test2.csv',{'unicode','simple'})
 b = a < 120
 b = dip.EdgeObjectsRemove(b)
 b = dip.Label(b)
-m = dip.MeasurementTool.Measure(b,features=['EllipseVariance','P2A','Roundness','Circularity','Solidity','Convexity'])
+m = dip.MeasurementTool.Measure(b,a,features=['EllipseVariance','P2A','Roundness','Circularity','Solidity','Convexity'])
 print(m)
 dip.Show(dip.ObjectToMeasurement(b,m['EllipseVariance']))
 dip.Show(dip.ObjectToMeasurement(b,m['Roundness']))


### PR DESCRIPTION
From the documentation 'grey' Must be given for the function Measure(). Else throws a TypeError: Incompatible function arguments