### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: cpp
+os: linux
+dist: xenial
+compiler:
+  - clang
+  - gcc
+before_script:
+  - mkdir build
+  - cd build
+script:
+  - cmake ..
+  - make -j2
+after_success:
+  - make check

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # *DIPlib 3*
+[![Build Status](https://travis-ci.org/DIPlib/diplib.svg?branch=master)](https://travis-ci.org/DIPlib/diplib)
 
 *DIPlib* is a library for quantitative image analysis. It has been in development
 at Delft University of Technology in The Netherlands since 1995. The 3.0 release


### PR DESCRIPTION
This adds basic Travis CI testing. The current setup runs `cmake`, `make` and `make check` on Ubuntu Xenial Xerus 16.04 on both GCC and Clang. It should be easy to extend this to Mac and Windows builds and other compilers, but I think this is a good start.

The second commit adds a build status badge to the README and is optional. It will look like [this](https://github.com/DIPlib/diplib/blob/801cae5d31165d9d008a064e62187b614c927e4c/README.md). If you think it is too gimmicky I can remove this commit.

Before merging this, you should first enable Travis. Do this by going to https://travis-ci.com/ , logging in with your GitHub account, and make sure you give it access to the DIPlib organization and this repository.