### PR TITLE
Also test macOS (Clang only) with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,27 @@
 language: cpp
-os: linux
-dist: xenial
-compiler:
-  - clang
-  - gcc
+matrix:
+  include:
+     - os: linux
+       dist: xenial
+       compiler: clang
+     - os: linux
+       dist: xenial
+       compiler: gcc
+     - os: osx
+       osx_image: xcode10.2
+       compiler: clang
 addons:
-   apt:
-      packages:
-         - freeglut3-dev
-         - libglfw3-dev
-         - python3-dev
+  apt:
+    packages:
+      - freeglut3-dev
+      - libglfw3-dev
+      - python3-dev
+  homebrew:
+    packages:
+      - freeglut
+      - glfw
+      - python
+
 script:
   - mkdir build
   - cd build


### PR DESCRIPTION
If I understand correctly, Xcode's GCC uses the same backend as Clang, so we don't need to test it separately.