### PR TITLE
Disable results for cpp/large-parameter on LGTM

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -5,6 +5,8 @@ path_classifiers:
    test:
       - exclude: /
       - examples/pydip_examples.py
+queries:
+   - exclude: cpp/large-parameter
 extraction:
    cpp:
       prepare:


### PR DESCRIPTION
Following feedback [on the LGTM forum](https://discuss.lgtm.com/t/bad-advice-large-object-passed-by-value/2026), this PR hides the results for the query `cpp/large-parameter`.