### PR TITLE
Test Windows build with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
      - os: osx
        osx_image: xcode10.2
        compiler: clang
+     - os: windows
 addons:
   apt:
     packages:
@@ -30,5 +31,5 @@ script:
   - cd build
   - export DIP_CMAKE_OPTS=$(if [[ $CC == "clang" ]]; then echo -n '-DDIP_ENABLE_MULTITHREADING=Off'; fi)
   - cmake $DIP_CMAKE_OPTS ..
-  - make -j2
-  - make check
+  - cmake --build . --parallel 2
+  - cmake --build . --target check


### PR DESCRIPTION
Seems to use Visual Studio 2017 by default, and builds fine.

Note: this doesn't build the optional stuff requiring freeglut, glfw or python, as I could not yet find an easy way to install those.