### PR TITLE
.lgtm.yml: remove GCC 6 override

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -12,14 +12,9 @@ extraction:
    cpp:
       prepare:
          packages:
-            - g++-6
             - freeglut3-dev
             - python3-dev
       after_prepare:
-         - mkdir -p $LGTM_WORKSPACE/latest-gcc-symlinks
-         - ln -s /usr/bin/g++-6 $LGTM_WORKSPACE/latest-gcc-symlinks/g++
-         - ln -s /usr/bin/gcc-6 $LGTM_WORKSPACE/latest-gcc-symlinks/gcc
-         - export PATH=$LGTM_WORKSPACE/latest-gcc-symlinks:$PATH
          - export GNU_MAKE=make
          - export GIT=true
          - mkdir $LGTM_SRC/target


### PR DESCRIPTION
This override of the compiler to always use GCC 6 seems to have been copied from [an example in the LGTM documentation](https://help.semmle.com/lgtm-enterprise/archive/1.22/user/help/lgtm.yml-configuration-file.html#example-lgtm.yml-file) that was not intended to be used literally. We'll update that example before our next release.

I've tested that the build still works at https://lgtm.com/logs/70c44efba7f75f0134be08b6f7197826a4ba02d6/lang:cpp.