### PR TITLE
Optimize feature measurements

### DIFF
--- a/include/diplib/accumulators.h
+++ b/include/diplib/accumulators.h
@@ -621,7 +621,7 @@ class DIP_NO_EXPORT MomentAccumulator {
       }
 
       /// \brief Add a sample to the accumulator. `pos` must have `N` dimensions.
-      void Push( FloatArray pos, dfloat weight ) {
+      void Push( FloatArray const& pos, dfloat weight ) {
          dip::uint N = m1_.size();
          DIP_ASSERT( pos.size() == N );
          m0_ += weight;

--- a/src/measurement/image_chain_code.cpp
+++ b/src/measurement/image_chain_code.cpp
@@ -19,7 +19,7 @@
  */
 
 #include <array>
-#include <map>
+#include <unordered_map>
 
 #include "diplib.h"
 #include "diplib/chain_code.h"
@@ -35,7 +35,7 @@ constexpr VertexInteger ChainCode::deltas8[8];
 namespace {
 
 struct ObjectData { dip::uint index; bool done; };
-using ObjectIdList = std::map< dip::uint, ObjectData >; // key is the objectID (label)
+using ObjectIdList = std::unordered_map< dip::uint, ObjectData >; // key is the objectID (label)
 
 template< typename TPI >
 static ChainCode GetOneChainCode(


### PR DESCRIPTION
Hey @crisluengo,

here are two little performance tweaks to the measurement code. Both bring measurable performance gains in their respective area. The chain code change alone speeds up our cell shape measurements by ~20% overall, which is extremely significant considering that the chain codes are then used subsequently to actually measure the features.

Cheers