### PR TITLE
Optimize FeatureDirectionalStatistics via LUT

### DIFF
--- a/include/diplib/accumulators.h
+++ b/include/diplib/accumulators.h
@@ -486,10 +486,18 @@ class DIP_NO_EXPORT DirectionalStatisticsAccumulator {
          sum_ = { 0.0, 0.0 };
       }
 
-      /// Add a sample to the accumulator
-      void Push( dfloat x ) {
+      /// Decompose a sample, useful to keep a cached lookup table
+      static dcomplex Decompose( dfloat x) {
+         return { std::cos( x ), std::sin( x ) };
+      }
+      /// Add a decomposed sample to the accumulator
+      void Push( dcomplex p ) {
          ++n_;
-         sum_ += dcomplex{ std::cos( x ), std::sin( x ) };
+         sum_ += p;
+      }
+      /// Decompose the sample and add it to the accumulator
+      void Push( dfloat x ) {
+         Push(Decompose(x));
       }
 
       /// Combine two accumulators

--- a/src/measurement/feature_directional_statistics.h
+++ b/src/measurement/feature_directional_statistics.h
@@ -60,7 +60,13 @@ class FeatureDirectionalStatistics : public LineBased {
                   }
                }
                if( data ) {
-                  data->Push( *grey );
+                  const auto x = *grey;
+                  auto &p = lut_[x];
+                  if (p == dcomplex{}) {
+                     p = DirectionalStatisticsAccumulator::Decompose(x);
+                  }
+
+                  data->Push( p );
                }
             }
             ++grey;
@@ -80,6 +86,7 @@ class FeatureDirectionalStatistics : public LineBased {
 
    private:
       std::vector< DirectionalStatisticsAccumulator > data_;
+      std::unordered_map<dfloat, dcomplex> lut_;
 };
 
 


### PR DESCRIPTION
Hey Cris,

I believe this patch is sane, but I don't have the full domain expertise. Do you agree with my assessment that there will be usually only a low number of different grey values encountered? This patch only makes sense in such a case, otherwise we would end up just doing more work than before.

At least in my adhoc tests, the assumption was valid. Before this patch I saw a big hotspot attributed to the repeated `sincos` calls. Afterwards only a bit of `std::unordered_map` lookups was left, but overall at a much reduced cost.

That said - are there some benchmarks for this code in the diplib repository itself that I could use to give you some hard numbers?