### PR TITLE
Wip/upstreaming

### DIFF
--- a/include/diplib/multithreading.h
+++ b/include/diplib/multithreading.h
@@ -58,6 +58,9 @@ namespace dip {
 /// If `nThreads` is 0, resets the maximum number of threads to the default value.
 ///
 /// If *DIPlib* was compiled without *OpenMP* support, this function does nothing.
+///
+/// Note that this number is thread-local. Meaning it only applies to the
+/// current thread from which this function is called.
 DIP_EXPORT void SetNumberOfThreads( dip::uint nThreads );
 
 
@@ -67,6 +70,9 @@ DIP_EXPORT void SetNumberOfThreads( dip::uint nThreads );
 /// function was never called.
 ///
 /// If *DIPlib* was compiled without *OpenMP* support, this function always returns 1.
+///
+/// Note that this number is thread-local. Meaning it only applies to the
+/// current thread from which this function is called.
 DIP_EXPORT dip::uint GetNumberOfThreads();
 
 

--- a/src/library/multithreading.cpp
+++ b/src/library/multithreading.cpp
@@ -24,15 +24,16 @@ namespace dip {
 
 namespace {
 
-dip::uint maxNumberOfThreads = static_cast< dip::uint >( omp_get_max_threads() ); // This responds to the OMP_NUM_THREADS environment variable.
+const dip::uint defaultMaxNumberOfThreads = static_cast< dip::uint >( omp_get_max_threads() ); // This responds to the OMP_NUM_THREADS environment variable.
+thread_local dip::uint maxNumberOfThreads = defaultMaxNumberOfThreads;
 
 }
 
 void SetNumberOfThreads( dip::uint nThreads ) {
    if( nThreads == 0 ) {
-      maxNumberOfThreads = static_cast< dip::uint >( omp_get_max_threads() );
+      maxNumberOfThreads = defaultMaxNumberOfThreads;
    } else {
-      maxNumberOfThreads = std::min( nThreads, static_cast< dip::uint >( omp_get_max_threads() ));
+      maxNumberOfThreads = std::min( nThreads, defaultMaxNumberOfThreads );
    }
 }
 

--- a/src/morphology/pathopening.cpp
+++ b/src/morphology/pathopening.cpp
@@ -265,7 +265,7 @@ void ConstrainedPathOpeningInternal(
       Image& im_olup,                     // temp: upstream length, non-straight
       Image& im_sldn,                     // temp: downstream length, straight
       Image& im_oldn,                     // temp: downstream length, non-straight
-      std::vector< dip::sint > offsets,   // array with offsets into images
+      std::vector< dip::sint > const& offsets,   // array with offsets into images
       IntegerArray const& offsetUp,       // offsets to upstream neighbors
       IntegerArray const& offsetDown,     // offsets to upstream neighbors
       dip::uint length                    // param

--- a/src/morphology/pathopening.cpp
+++ b/src/morphology/pathopening.cpp
@@ -280,8 +280,7 @@ void ConstrainedPathOpeningInternal(
    PixelQueue queue;
    PixelQueue changed;
 
-   for( dip::uint jj = 0; jj < offsets.size(); ++jj ) {
-      dip::sint offset = offsets[ jj ];
+   for( auto offset : offsets ) {
       if( !( active[ offset ] & PO_ACTIVE )) {
          continue;
       }


### PR DESCRIPTION
Hey Cris,

here are some more little fixes I would like to upstream.

Many thanks with the hint about the call to `dip::SetNumberOfThreads` - that indeed fixes my problem! I just realize that it would negatively influence other threads (and introduce a datarace) if I'd call it from our code. This patch here should fix that and sounds like a generally good thing to do I believe, as the OpenMP thread pool is thread-local too.

Cheers