### PR TITLE
Fix compile with g++11

### DIFF
--- a/include/diplib/library/types.h
+++ b/include/diplib/library/types.h
@@ -36,6 +36,7 @@
 #include <set>
 #include <cctype>
 #include <climits>
+#include <limits>
 
 #include "diplib/library/dimension_array.h"
 


### PR DESCRIPTION
Without the explicit include of `<limits>`, the compiler will fail
when std::numeric_limits is used in the types.h header.
