### PR TITLE
Add missing defaulted ctor, dtor and operator= for Histogram

### DIFF
--- a/include/diplib/histogram.h
+++ b/include/diplib/histogram.h
@@ -307,6 +307,15 @@ class DIP_NO_EXPORT Histogram {
          DIP_STACK_TRACE_THIS( HistogramFromDataPointer( data, configuration ));
       }
 
+      /// \brief The default-initialized histogram is empty
+      Histogram() = default;
+      // Copy constructor, move constructor/assignment and destructor are all default.
+      Histogram(const Histogram &rhs) = default;
+      Histogram(Histogram &&rhs) = default;
+      Histogram &operator=(const Histogram &rhs) = default;
+      Histogram &operator=(Histogram &&rhs) = default;
+      ~Histogram() = default;
+
       /// \brief Swaps `this` and `other`.
       void swap( Histogram& other ) {
          using std::swap;


### PR DESCRIPTION
The histogram class has many constructors, but was missing all
of the default constructors. This made it much harder to use, one
would not be able to cmopile `std::vector<dip::Histogram>(5)` e.g.

Personally I don't see a reason why it should be forbidden to
construct an empty histogram.

@crisluengo I also see that the other ctors are explicitly checking if the input image is forged, and throw an exception otherwise. Why is that? I also find that quite unexpected. To me, it sounds like a valid operation to do, and the result should be an empty histogram...