### PR TITLE
Unbreak GaussianMixtureModelThreshold

### DIFF
--- a/src/histogram/threshold_algorithms.cpp
+++ b/src/histogram/threshold_algorithms.cpp
@@ -258,7 +258,7 @@ FloatArray GaussianMixtureModelThreshold(
       data[ ii ] = static_cast< dfloat >( pData[ ii ] );
    }
    std::vector< dfloat > weights( nBins * nGaussians, 1.0 );
-   std::vector< GaussianParameters > params = GaussianMixtureModel( data.data(), weights.data(), {}, nBins, nGaussians );
+   std::vector< GaussianParameters > params = GaussianMixtureModel( data.data(), weights.data(), nBins, nGaussians );
    // Sort Gaussians by position
    std::sort( params.begin(), params.end(), []( GaussianParameters const& a, GaussianParameters const& b ) { return a.position < b.position; } );
    // Find thresholds


### PR DESCRIPTION
The internal call to GaussianMixtureModel was passing `size = {} = 0`
which leads to totally bogus computation of gaussian parametesr.
Basically, the parameters will always be:

```
Gaussian: position =  0 , amplitude =  nan , sigma =  0
```

And then the thresholding logic would just operate on the
bin size and lower bound.

Fix this by actually passing the right parameters instead.

@crisluengo sounds like a test is missing for this function ;-) I was quite surprised by the results for this function