### PR TITLE
Don't try loading javaio until needed.

### DIFF
--- a/pydip/src/__init__.py.in
+++ b/pydip/src/__init__.py.in
@@ -19,6 +19,7 @@ This module is PyDIP, the Python interface to DIPlib.
 See the User Manual online: https://diplib.org/diplib-docs/pydip_user_manual.html
 """
 
+import functools
 import os
 import sys
 import time
@@ -146,52 +147,68 @@ if importlib.util.find_spec('.PyDIPviewer', __name__) is not None:
                 viewer.Draw()
                 time.sleep(0.001)
 
+
+# LRU cache really means that this function is only ever called once and the
+# return value reused afterwards.
+@functools.lru_cache()
+def _get_javaio_imageread_or_error():
+    # Here we import PyDIPjavaio if it exists
+    hasDIPjavaio = False
+    javaioError = (
+        "If you were trying to read an image format supported by BioFormats, "
+        "note that DIPjavaio is unavailable because:\n - ")
+    if importlib.util.find_spec('.PyDIPjavaio', __name__) is not None:
+        _lib = None
+        try:
+            from . import loadjvm
+            _lib = loadjvm.load_jvm()
+            from . import PyDIPjavaio
+            # Replace the ImageRead from PyDIP_bin with the one in PyDIPjavaio, so that 'bioformats' is recognized as a "format".
+            return PyDIPjavaio.ImageRead
+        except Exception as e:
+            javaioError += str(e)
+            if _lib:
+                javaioError += f"\nload_jvm returned '{_lib}'"
+            else:
+                javaioError += "\nlibjvm not found"
+    else:
+        javaioError += "PyDIPjavaio was not included in the build of the package."
+    return javaioError
+
+
 # This is a version of ImageRead that we use if we fail to load PyDIPjavaio for any reason
 _reportedDIPjavaio = False
 def ImageRead(*args, **kwargs):
-    """You are using this version of dip.ImageRead() because the DIPjavaio module is
-    not available. See `dip.javaioError` for the reason it is not available.
+    """
+    Either call PyDIPjavaio.ImageRead (if available) or fall back to
+    PyDIP_bin.ImageRead otherwise.
 
-    This version of dip.ImageRead() can read ICS, TIFF, JPEG and NYP files. For other
-    formats you need DIPjavaio. You can also use the imageio package to load
-    image files.
-
-    To use the DIPjavaio module, you need:
+    PyDIPjavaio.ImageRead can read formats supported by BioFormats.  To use it,
+    you need:
     1. Have a PyDIP build that includes it (if you got this from PyPI, it is included).
     2. Have a working installation of a Java VM. Download: https://www.java.com/en/
     3. Run `python -m diplib download_bioformats` from your shell.
-    """
-    global _reportedDIPjavaio
-    try:
-        return PyDIP_bin.ImageRead(*args, **kwargs)
-    except BaseException:
-        if not _reportedDIPjavaio:
-            print(
-"""If you were trying to read an image format supported by BioFormats, note that
-DIPjavaio is unavailable because:""")
-            print(f" - {javaioError}\n")
-            _reportedDIPjavaio = True
-        raise
 
-# Here we import PyDIPjavaio if it exists
-hasDIPjavaio = False
-if importlib.util.find_spec('.PyDIPjavaio', __name__) is not None:
-    _lib = None
-    try:
-        from . import loadjvm
-        _lib = loadjvm.load_jvm()
-        from . import PyDIPjavaio as javaio
-        # Replace the ImageRead from PyDIP_bin with the one in PyDIPjavaio, so that 'bioformats' is recognized as a "format".
-        ImageRead = javaio.ImageRead
-        hasDIPjavaio = True
-    except Exception as e:
-        javaioError = str(e)
-        if _lib:
-            javaioError += f"\nload_jvm returned '{_lib}'"
-        else:
-            javaioError += "\nlibjvm not found"
-else:
-    javaioError = "PyDIPjavaio was not included in the build of the package."
+    PyDIP_bin.ImageRead can only read ICS, TIFF, JPEG and NPY files.
+
+    You can also use the imageio package to load image files.
+    """
+    javaio_imageread_or_error = _get_javaio_imageread_or_error()
+    if callable(javaio_imageread_or_error):
+        javaio_imageread = javaio_imageread_or_error
+        return javaio_imageread(*args, **kwargs)
+
+    else:
+        javaio_error = javaio_imageread_or_error
+        global _reportedDIPjavaio
+        try:
+            return PyDIP_bin.ImageRead(*args, **kwargs)
+        except BaseException:
+            if not _reportedDIPjavaio:
+                print(javaio_error)
+                _reportedDIPjavaio = True
+            raise
+
 
 # Here we display library information
 if hasattr(sys,'ps1'):


### PR DESCRIPTION
This can speed up the initial import of diplib ~2x.  Note that the cost of import is never paid if the user never calls ImageRead (e.g. because they are already using an external library such as imageio).

(Somewhat similar in idea to #127.)

Note that this technically breaks backcompat by removing the hasDIPjavaio and javaioError globals.  If keeping them is important, they can still be generated using a module-level `__getattr__` (so that again we try to load the jvm only when really needed), just let me know.