### PR TITLE
initialize an element of the array to comply with gcc's warning

### DIFF
--- a/dependencies/pocketfft/pocketfft_hdronly.h
+++ b/dependencies/pocketfft/pocketfft_hdronly.h
@@ -2366,6 +2366,7 @@ template<typename T0> class fftblue
     template<bool fwd, typename T> void fft(cmplx<T> c[], T0 fct) const
       {
       arr<cmplx<T>> akf(n2);
+      akf[0] = cmplx<T>(0,0);
 
       /* initialize a_k and FFT it */
       for (size_t m=0; m<n; ++m)


### PR DESCRIPTION
In the spirit of avoiding triggering compiler warnings (as also discussed in #152) this is a simple fix to take care of the following uninitialized warning which is repeated 4 times

```c++
In file included from /home/davide/repo/github/diplib_davide/src/transform/dft.cpp:39:
In member function ‘pocketfft::detail::cmplx<decltype ((((const pocketfft::detail::cmplx<T>*)this)->pocketfft::detail::cmplx<T>::r * other))> pocketfft::detail::cmplx<T>::operator*(const T2&) const [with T2 = double; T = double]’,
    inlined from ‘void pocketfft::detail::fftblue<T0>::fft(pocketfft::detail::cmplx<T2>*, T0) const [with bool fwd = true; T = double; T0 = double]’ at /home/davide/repo/github/diplib_davide/dependencies/pocketfft/pocketfft_hdronly.h:2373:25,
    inlined from ‘void pocketfft::detail::fftblue<T0>::exec_r(T*, T0, bool) [with T = double; T0 = double]’ at /home/davide/repo/github/diplib_davide/dependencies/pocketfft/pocketfft_hdronly.h:2438:18,
    inlined from ‘void pocketfft::detail::pocketfft_r<T0>::exec(T*, T0, bool) const [with T = double; T0 = double]’ at /home/davide/repo/github/diplib_davide/dependencies/pocketfft/pocketfft_hdronly.h:2525:64:
/home/davide/repo/github/diplib_davide/dependencies/pocketfft/pocketfft_hdronly.h:252:15: warning: ‘*(const __vector(2) double*)res’ may be used uninitialized [-Wmaybe-uninitialized]
  252 |     { return {r*other, i*other}; }
      |               ^
```