### PR TITLE
Add support for writing of 3D Tiff images

### DIFF
--- a/include/diplib/file_io.h
+++ b/include/diplib/file_io.h
@@ -414,9 +414,6 @@ DIP_EXPORT bool ImageIsTIFF( String const& filename );
 /// The TIFF image file format is very flexible in how data can be written, but is limited to multiple pages
 /// of 2D images. A 3D image will be written as a multi-page TIFF file.
 ///
-/// !!! warning
-///     Writing of 3D images has not yet been implemented.
-///
 /// A tensor image will be written as an image with multiple samples per pixel, but the tensor shape will be lost.
 /// If the tensor image has color space information, and it is one of the few color spaces known to the TIFF
 /// standard, this information will be stored; images in other color spaces are stored without color space information.

--- a/src/file_io/tiff_write.cpp
+++ b/src/file_io/tiff_write.cpp
@@ -434,7 +434,7 @@ DOCTEST_TEST_CASE( "[DIPlib] testing TIFF file reading and writing" ) {
    }
 
    dip::ImageWriteTIFF( image3D, "test3.tif" );
-   result = dip::ImageReadTIFF( "test3", {0, Slices - 1} );
+   result = dip::ImageReadTIFF( "test3", {0, -1} );
    DOCTEST_CHECK( dip::testing::CompareImages( image3D, result ));
    DOCTEST_CHECK( image3D.PixelSize() == result.PixelSize() );
 
@@ -447,7 +447,7 @@ DOCTEST_TEST_CASE( "[DIPlib] testing TIFF file reading and writing" ) {
    result.SetStrides( strides );
    result.Forge();
    result.Protect();
-   dip::ImageReadTIFF( result, "test3", {0, Slices - 1} );
+   dip::ImageReadTIFF( result, "test3", {0, -1} );
    DOCTEST_CHECK( dip::testing::CompareImages( image3D, result ));
    DOCTEST_CHECK( image3D.PixelSize() == result.PixelSize() );
    result.Protect( false );
@@ -455,7 +455,7 @@ DOCTEST_TEST_CASE( "[DIPlib] testing TIFF file reading and writing" ) {
    // Turn it on its side so the image to write has non-standard strides
    image3D.SwapDimensions( 0, 1 );
    dip::ImageWriteTIFF( image3D, "test4.tif" );
-   result = dip::ImageReadTIFF( "test4", {0, Slices - 1} );
+   result = dip::ImageReadTIFF( "test4", {0, -1} );
    DOCTEST_CHECK( dip::testing::CompareImages( image3D, result ));
 }
 


### PR DESCRIPTION
The current version of function `dip::ImageWriteTiff` does not support writing 3D images. This pull request adds support for this, using `TIFFWriteDirectory`. It also adds some additional tests, to ensure the behavior is properly implemented.

If anything is missing, feel free to let me know.