### PR TITLE
migrate to new ftp server for legacy diplib (version 2 and lower)

### DIFF
--- a/doc/release_procedure/DIPimage_on_Windows.md
+++ b/doc/release_procedure/DIPimage_on_Windows.md
@@ -84,7 +84,7 @@ Also the following dependencies have been downloaded:
 
 For testing the *DIPlib* images are used:
 
-- *DIPlib* images <https://qiftp.tudelft.nl/diplib/images.zip>
+- *DIPlib* images <https://ftp.imphys.tudelft.nl/DIPimage/images.zip>
 
 ### FFTW static library
 

--- a/doc/src/DIPimage/01_introduction.md
+++ b/doc/src/DIPimage/01_introduction.md
@@ -63,7 +63,7 @@ This manual is meant as an introduction and reference to the *DIPimage*
 toolbox, not as a tutorial on image analysis. Although
 \ref sec_dum_gettingstarted shows some image analysis basics, it
 is not complete. We refer to
-["The Fundamentals of Image Processing"](https://qiftp.tudelft.nl/diplib/docs/FIP2.3.pdf).
+["The Fundamentals of Image Processing"](https://ftp.imphys.tudelft.nl/DIPimage/docs/FIP2.3.pdf).
 
 \section sec_dum_introduction_conventions Documentation conventions
 

--- a/doc/src/DIPimage/03_getting_started.md
+++ b/doc/src/DIPimage/03_getting_started.md
@@ -257,7 +257,7 @@ f = sz\calc
 
 If you are new to *MATLAB*, it would be a good idea to read the "Getting
 Started with *MATLAB*" manual. If you are new to image processing, you can
-read ["The Fundamentals of Image Processing"](https://qiftp.tudelft.nl/diplib/docs/FIP2.3.pdf).
+read ["The Fundamentals of Image Processing"](https://ftp.imphys.tudelft.nl/DIPimage/docs/FIP2.3.pdf).
 
 Before you start using this toolbox, we recommend that you read
 \ref "sec_dum_dip_image" (at least \ref sec_dum_dip_image_review).


### PR DESCRIPTION
The server `qiftp.tudelft.nl` is replaced with `ftp.imphys.tudelft.nl`. This pull request modifies the documentation accordingly.