### PR TITLE
Very minor edit following Polygon getting its own include file

### DIFF
--- a/include/diplib/generation.h
+++ b/include/diplib/generation.h
@@ -36,7 +36,7 @@ using FT_Face = struct FT_FaceRec_*;
 
 namespace dip {
 
-// Forward declaration, defined in chain_code.h
+// Forward declaration, defined in polygon.h
 struct DIP_NO_EXPORT Polygon;
 
 /// \group generation Generation


### PR DESCRIPTION
Rational: 

Make it more explicit where Polygon come from. That very very minor point, but as I followed the code (learning from it) I noticed that Polygon has now its own include file... it seem to be a good idea to reflect that in this comment.