### PR TITLE
missing DIP_EXPORT for Pixel operator !=

### DIFF
--- a/include/diplib/library/image_views.h
+++ b/include/diplib/library/image_views.h
@@ -784,6 +784,7 @@ bool operator==( Image::Pixel const& lhs, T const& rhs ) { return operator==( lh
 
 /// \brief Comparison operator, equivalent to `!(lhs==rhs)`.
 /// \relates dip::Image::Pixel
+DIP_EXPORT bool operator!=( Image::Pixel const& lhs, Image::Pixel const& rhs );
 template< typename T, typename = std::enable_if_t< IsNumericType< T >::value >>
 bool operator!=( Image::Pixel const& lhs, T const& rhs ) { return !operator==( lhs, rhs ); }
 

--- a/include/diplib/library/image_views.h
+++ b/include/diplib/library/image_views.h
@@ -784,7 +784,7 @@ bool operator==( Image::Pixel const& lhs, T const& rhs ) { return operator==( lh
 
 /// \brief Comparison operator, equivalent to `!(lhs==rhs)`.
 /// \relates dip::Image::Pixel
-DIP_EXPORT bool operator!=( Image::Pixel const& lhs, Image::Pixel const& rhs );
+DIP_EXPORT inline bool operator!=( Image::Pixel const& lhs, Image::Pixel const& rhs ) { return !( lhs == rhs ); }
 template< typename T, typename = std::enable_if_t< IsNumericType< T >::value >>
 bool operator!=( Image::Pixel const& lhs, T const& rhs ) { return !operator==( lhs, rhs ); }
 

--- a/src/math/pixel.cpp
+++ b/src/math/pixel.cpp
@@ -354,6 +354,10 @@ bool operator==( Image::Pixel const& lhs, Image::Pixel const& rhs ) {
    return res.All();
 }
 
+bool operator!=( Image::Pixel const& lhs, Image::Pixel const& rhs ) {
+   return !( lhs == rhs );
+}
+
 namespace {
 
 template< typename F >

--- a/src/math/pixel.cpp
+++ b/src/math/pixel.cpp
@@ -354,10 +354,6 @@ bool operator==( Image::Pixel const& lhs, Image::Pixel const& rhs ) {
    return res.All();
 }
 
-bool operator!=( Image::Pixel const& lhs, Image::Pixel const& rhs ) {
-   return !( lhs == rhs );
-}
-
 namespace {
 
 template< typename F >


### PR DESCRIPTION
attempt to fix #208

```
//doesn't compile missing DIP_EXPORT for Image::Pixel != Image::Pixel in include/diplib/library/image_views.h at line 787
if ( kernelImageA.At(0) != kernelImageB.At(0) ) {
    std::cout << "also expected" << std::endl;
}
```