### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/dependencies/libtiff/libtiff/tif_getimage.c
+++ b/dependencies/libtiff/libtiff/tif_getimage.c
@@ -29,6 +29,7 @@
  */
 #include "tiffiop.h"
 #include <stdio.h>
+#include <limits.h>
 
 static int gtTileContig(TIFFRGBAImage*, uint32*, uint32, uint32);
 static int gtTileSeparate(TIFFRGBAImage*, uint32*, uint32, uint32);
@@ -650,10 +651,18 @@ gtTileContig(TIFFRGBAImage* img, uint32* raster, uint32 w, uint32 h)
 
     flip = setorientation(img);
     if (flip & FLIP_VERTICALLY) {
+       if ((tw + w) > INT_MAX) {
+            TIFFErrorExt(tif->tif_clientdata, TIFFFileName(tif), "%s", "unsupported tile size (too wide)");
+            return (0);
+       }
 	    y = h - 1;
 	    toskew = -(int32)(tw + w);
     }
     else {
+       if ((tw + w) > INT_MAX) {
+            TIFFErrorExt(tif->tif_clientdata, TIFFFileName(tif), "%s", "unsupported tile size (too wide)");
+            return (0);
+       }
 	    y = 0;
 	    toskew = -(int32)(tw - w);
     }


### PR DESCRIPTION
This PR fixes a potential security vulnerability in gtTileContig() that was cloned from https://gitlab.com/libtiff/libtiff but did not receive the security patch.

### Details:
Affected Function: gtTileContig() in dependencies/libtiff/libtiff/tif_getimage.c
Original Fix: https://gitlab.com/libtiff/libtiff/-/commit/c8d613ef497058fe653c467fc84c70a62a4a71b2

### What this PR does:
This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

### References:
- https://gitlab.com/libtiff/libtiff/-/commit/c8d613ef497058fe653c467fc84c70a62a4a71b2
- https://nvd.nist.gov/vuln/detail/cve-2020-35523

Please review and merge this PR to ensure your repository is protected against this potential vulnerability.