### PR TITLE
Add centroid diameter

### DIFF
--- a/doc/src/features.md
+++ b/doc/src/features.md
@@ -112,6 +112,41 @@ The first three values are reported in physical units, but only for isotropic (s
 (otherwise the pixel sizes are ignored). The last two values are reported in radian, assuming
 isotropic pixels.
 
+\subsection size_features_CentroidDiameter CentroidDiameter
+Computes the maximum and minimum object diameter measured as a chord through the object's
+centroid. For every point on the object's boundary, the width of the object is computed as
+the distance to the boundary point diametrically opposite it (in the direction rotated by
+\f$\pi\f$), as seen from the object's centroid. The minimum and maximum of this width, taken
+over the whole boundary, are reported, together with the angle at which each was found.
+
+Note that the chain code measures work only for 2D images, and expect objects to be a single
+connected component. If multiple connected components have the same label, only the first
+connected component found for that label will be measured.
+
+Unlike \ref size_features_Feret, which is based on the object's convex hull, `CentroidDiameter`
+uses the object's full boundary. This makes it sensitive to concave defects (a chip, notch, or
+flat spot) that `Feret` cannot detect by construction: the convex hull bridges over any
+concavity, whereas a chord through the centroid can pass right through it.
+
+!!! note
+    This is related to, but distinct from, the classical "Martin diameter" of the particle
+    characterization literature, which is the chord that divides the particle's area in half
+    at a given angle. `CentroidDiameter` instead always passes through the centroid. This is
+    considerably cheaper to compute (the classical Martin diameter requires a search for the
+    area-bisecting position at each angle, rather than a single lookup), and the two measures
+    coincide for centrally symmetric shapes, but they can diverge for strongly asymmetric ones.
+
+Four values are returned:
+
+ - 0: `Max`, the maximum diameter through the centroid.
+ - 1: `Min`, the minimum diameter through the centroid.
+ - 2: `MaxAng`, the angle at which `Max` was obtained.
+ - 3: `MinAng`, the angle at which `Min` was obtained.
+
+The first two values are reported in physical units, but only for isotropic (square) pixels
+(otherwise the pixel sizes are ignored). The last two values are reported in radian, assuming
+isotropic pixels.
+
 \subsection shape_features_Radius Radius
 Statistics on the radius of the object, computed from the chain code using
 \ref dip::ChainCode::Polygon and \ref dip::Polygon::RadiusStatistics.

--- a/include/diplib/measurement.h
+++ b/include/diplib/measurement.h
@@ -938,6 +938,7 @@ class DIP_CLASS_EXPORT Composite : public Base {
 /// `"Maximum"`                 | Maximum coordinates of the object |
 /// `"CartesianBox"`            | Cartesian box size of the object in all dimensions |
 /// `"Feret"`                   | Maximum and minimum object diameters | 2D (CC)
+/// `"CentroidDiameter"`        | Maximum and minimum object diameters through the centroid | 2D (CC)
 /// `"Radius"`                  | Statistics on radius of object | 2D (CC)
 /// `"ConvexArea"`              | Area of the convex hull | 2D (CC)
 /// `"ConvexPerimeter"`         | Perimeter of the convex hull | 2D (CC)

--- a/src/DIPlib_sources.cmake
+++ b/src/DIPlib_sources.cmake
@@ -195,6 +195,7 @@ measurement/feature_aspect_ratio_feret.h
 measurement/feature_bending_energy.h
 measurement/feature_cartesian_box.h
 measurement/feature_center.h
+measurement/feature_centroid_diameter.h
 measurement/feature_circularity.h
 measurement/feature_common_stuff.h
 measurement/feature_convex_area.h

--- a/src/measurement/feature_centroid_diameter.h
+++ b/src/measurement/feature_centroid_diameter.h
@@ -18,26 +18,6 @@
 namespace dip {
 namespace Feature {
 
-
-/// \brief Maximum and minimum object diameters, measured as chords through the object's centroid.
-///
-/// For every point on the object's boundary, the object's width is computed as the distance to
-/// the boundary point diametrically opposite it (in the direction rotated by `pi`), as seen from
-/// the object's centroid (see \ref "Center"). The minimum and maximum of this width, taken over
-/// the whole boundary, are reported, together with the angle at which each was found.
-///
-/// !!! note
-///     This is related to, but distinct from, the classical "Martin diameter" of the particle
-///     characterization literature, which is the chord that divides the particle's area in half
-///     at a given angle. `CentroidDiameter` instead always passes through the centroid. This is
-///     considerably cheaper to compute (the classical Martin diameter requires a search for the
-///     area-bisecting position at each angle, rather than a single lookup), and the two measures
-///     coincide for centrally symmetric shapes, but they can diverge for strongly asymmetric ones.
-///
-/// Unlike \ref "Feret", which is based on the object's convex hull, `CentroidDiameter` uses the
-/// object's full boundary. This makes it sensitive to concave defects (a chip, notch, or flat
-/// spot) that `Feret` cannot detect by construction: the convex hull bridges over any concavity,
-/// whereas a chord through the centroid can pass right through it.
 class FeatureCentroidDiameter : public PolygonBased {
    public:
       FeatureCentroidDiameter() : PolygonBased( { "CentroidDiameter", "Maximum and minimum object diameters through the centroid (2D)", false } ) {};

--- a/src/measurement/feature_centroid_diameter.h
+++ b/src/measurement/feature_centroid_diameter.h
@@ -1,0 +1,142 @@
+/*
+ * (c)2026, Tolga Ciftcicelik.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+namespace dip {
+namespace Feature {
+
+
+/// \brief Maximum and minimum object diameters, measured as chords through the object's centroid.
+///
+/// For every point on the object's boundary, the object's width is computed as the distance to
+/// the boundary point diametrically opposite it (in the direction rotated by `pi`), as seen from
+/// the object's centroid (see \ref "Center"). The minimum and maximum of this width, taken over
+/// the whole boundary, are reported, together with the angle at which each was found.
+///
+/// !!! note
+///     This is related to, but distinct from, the classical "Martin diameter" of the particle
+///     characterization literature, which is the chord that divides the particle's area in half
+///     at a given angle. `CentroidDiameter` instead always passes through the centroid. This is
+///     considerably cheaper to compute (the classical Martin diameter requires a search for the
+///     area-bisecting position at each angle, rather than a single lookup), and the two measures
+///     coincide for centrally symmetric shapes, but they can diverge for strongly asymmetric ones.
+///
+/// Unlike \ref "Feret", which is based on the object's convex hull, `CentroidDiameter` uses the
+/// object's full boundary. This makes it sensitive to concave defects (a chip, notch, or flat
+/// spot) that `Feret` cannot detect by construction: the convex hull bridges over any concavity,
+/// whereas a chord through the centroid can pass right through it.
+class FeatureCentroidDiameter : public PolygonBased {
+   public:
+      FeatureCentroidDiameter() : PolygonBased( { "CentroidDiameter", "Maximum and minimum object diameters through the centroid (2D)", false } ) {};
+
+      ValueInformationArray Initialize( Image const& label, Image const&, dip::uint ) override {
+         ValueInformationArray out( 4 );
+         PhysicalQuantity pq = label.PixelSize().UnitLength();
+         scale_ = pq.magnitude;
+         out[ 0 ].units = pq.units;
+         out[ 1 ].units = pq.units;
+         out[ 2 ].units = Units::Radian();
+         out[ 3 ].units = Units::Radian();
+         out[ 0 ].name = "Max";
+         out[ 1 ].name = "Min";
+         out[ 2 ].name = "MaxAng";
+         out[ 3 ].name = "MinAng";
+         return out;
+      }
+
+      void Measure( Polygon const& polygon, Measurement::ValueIterator output ) override {
+         struct Sample {
+            dfloat angle;
+            dfloat radius;
+         };
+         VertexFloat centroid = polygon.Centroid();
+         std::vector< Sample > samples;
+         samples.reserve( polygon.vertices.size() );
+         for( auto const& v : polygon.vertices ) {
+            dfloat dx = v.x - centroid.x;
+            dfloat dy = v.y - centroid.y;
+            samples.push_back( { std::atan2( dy, dx ), std::hypot( dx, dy ) } );
+         }
+         if( samples.size() < 2 ) {
+            // Degenerate polygon, not enough vertices to compute a meaningful diameter.
+            output[ 0 ] = 0;
+            output[ 1 ] = 0;
+            output[ 2 ] = 0;
+            output[ 3 ] = 0;
+            return;
+         }
+         std::sort( samples.begin(), samples.end(), []( Sample const& a, Sample const& b ) {
+            return a.angle < b.angle;
+         } );
+         dip::uint n = samples.size();
+
+         // Linearly interpolates the object's radius at an arbitrary angle, between the two
+         // nearest samples. The polygon typically has one vertex per boundary pixel, so this
+         // interpolation error is sub-pixel.
+         auto radiusAt = [ & ]( dfloat angle ) {
+            while( angle < -pi ) {
+               angle += 2.0 * pi;
+            }
+            while( angle >= pi ) {
+               angle -= 2.0 * pi;
+            }
+            dip::uint idx = static_cast< dip::uint >( std::lower_bound( samples.begin(), samples.end(), angle,
+                  []( Sample const& s, dfloat a ) { return s.angle < a; } ) - samples.begin() );
+            dip::uint i0 = ( idx == 0 ) ? ( n - 1 ) : ( idx - 1 );
+            dip::uint i1 = idx % n;
+            dfloat a0 = samples[ i0 ].angle;
+            dfloat a1 = samples[ i1 ].angle;
+            dfloat da = a1 - a0;
+            if( da < 0 ) {
+               da += 2.0 * pi;
+            }
+            dfloat t = angle - a0;
+            if( t < 0 ) {
+               t += 2.0 * pi;
+            }
+            t = ( da < 1e-9 ) ? 0.0 : ( t / da );
+            return samples[ i0 ].radius + t * ( samples[ i1 ].radius - samples[ i0 ].radius );
+         };
+
+         dfloat diameterMin = std::numeric_limits< dfloat >::max();
+         dfloat diameterMax = 0;
+         dfloat minAngle = 0;
+         dfloat maxAngle = 0;
+         for( auto const& s : samples ) {
+            dfloat diameter = s.radius + radiusAt( s.angle + pi );
+            if( diameter < diameterMin ) {
+               diameterMin = diameter;
+               minAngle = s.angle;
+            }
+            if( diameter > diameterMax ) {
+               diameterMax = diameter;
+               maxAngle = s.angle;
+            }
+         }
+
+         output[ 0 ] = diameterMax * scale_;
+         output[ 1 ] = diameterMin * scale_;
+         output[ 2 ] = maxAngle;
+         output[ 3 ] = minAngle;
+      }
+
+   private:
+      dfloat scale_;
+};
+
+
+} // namespace Feature
+} // namespace dip

--- a/src/measurement/measurement_tool.cpp
+++ b/src/measurement/measurement_tool.cpp
@@ -39,6 +39,7 @@
 #include "feature_perimeter.h"
 #include "feature_surface_area.h"
 #include "feature_feret.h"
+#include "feature_centroid_diameter.h"
 #include "feature_convex_area.h"
 #include "feature_convex_perimeter.h"
 // Shape
@@ -92,6 +93,7 @@ MeasurementTool::MeasurementTool() {
    Register( new Feature::FeatureMaximum );
    Register( new Feature::FeatureCartesianBox );
    Register( new Feature::FeatureFeret );
+   Register( new Feature::FeatureCentroidDiameter );
    Register( new Feature::FeatureRadius );
    Register( new Feature::FeatureConvexArea );
    Register( new Feature::FeatureConvexPerimeter );


### PR DESCRIPTION
Title: Add `CentroidDiameter` measurement feature

## Summary

Adds a new `PolygonBased` measurement feature, `CentroidDiameter`, that
reports the maximum and minimum object diameter measured as a chord through
the object's centroid (plus the angle at which each extreme was found).

This complements `Feret`: `Feret` is convex-hull based and is therefore
structurally blind to concave boundary defects (a chip, notch, or flat
spot), since the convex hull bridges over them. `CentroidDiameter` uses the
full boundary, so it correctly reflects such defects. See discussion in
#231.

Files changed:
- `src/measurement/feature_centroid_diameter.h` (new) — the feature
  implementation, modeled on `feature_feret.h` / `feature_radius.h`.
- `src/measurement/measurement_tool.cpp` — `#include` and `Register()` the
  new feature, next to `Feret`.
- `include/diplib/measurement.h` — added a row to the features table.

## Design notes

- Per the discussion in #231, this is intentionally *not* called
  "Martin diameter": the classical Martin diameter is the area-bisecting
  chord at a given angle, which requires a search for the correct offset at
  each angle. `CentroidDiameter` always passes through the centroid, which
  is a single `O(log n)` lookup per angle instead, and coincides with the
  Martin diameter for centrally symmetric shapes but can diverge for
  strongly asymmetric ones. The doc comment explains this relationship.
- Implementation is `O(n log n)` per object (sort dominates): for every
  polygon vertex, look up the boundary radius at the exact opposite angle
  by linearly interpolating between the two nearest angle-sorted samples,
  and take the min/max of the summed width over all vertices.
- Output units: `Max`/`Min` get the label's length unit (matching `Feret`),
  `MaxAng`/`MinAng` are in radians (matching `Feret`'s `MaxAng`/`MinAng`).

## Test plan

- [x] Built the full library (`DIP_ENABLE_ZLIB=OFF` locally due to an
      unrelated zlib/Xcode-SDK toolchain incompatibility on my machine, not
      related to this change) with no new warnings under
      `-Wall -Wconversion -Wsign-conversion -pedantic`.
- [x] Ran the existing `unit_tests` (`make check`) suite: 2946/2946
      assertions pass; the only 2 failing test cases (ICS/TIFF compressed
      I/O) are pre-existing and caused by `DIP_ENABLE_ZLIB=OFF`, unrelated
      to this change.
- [x] Verified numerically against an independent prototype implementation
      (not part of this PR) on both a synthetic notched shape and a
      multi-hole test image; results matched to the last reported digit.
- [ ] No dedicated `DOCTEST_TEST_CASE` yet — happy to add one (e.g.
      modeled on the `Feret`/`Radius` checks in `measure_polygon.cpp`) if
      you'd like it in this PR rather than as a follow-up.

Closes #231.