### PR TITLE
Add dip_qimage_interface.h: copyless dip::Image <-> QImage conversion

### DIFF
--- a/doc/src/main.md
+++ b/doc/src/main.md
@@ -63,6 +63,9 @@ Currently, *DIPlib 3* has interfaces or bindings to the following packages:
 - *Vigra*: the \ref dip_vigra_interface provides copyless conversion to and from
   [*Vigra*](http://ukoethe.github.io/vigra/) images.
 
+  - *Qt*: the \ref dip_qimage_interface provides copyless conversion to and from
+  [*Qt*](https://www.qt.io)'s `QImage`.
+
 The *DIPlib* project further contains these additional modules:
 
 - \ref dipviewer: an interactive image display utility.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -192,6 +192,22 @@ if(DIP_BUILD_DIPVIEWER)
 
 endif(DIP_BUILD_DIPVIEWER)
 
+## An example that needs Qt, compile only if Qt is available
+
+find_package(Qt6 QUIET COMPONENTS Widgets)
+if(Qt6_FOUND)
+
+   # An example program that uses both DIPlib and Qt's QImage
+   add_executable(qt_with_dip external_interfaces/qt_with_dip.cpp)
+   target_compile_definitions(qt_with_dip PRIVATE DIP_EXAMPLES_DIR="${CMAKE_CURRENT_LIST_DIR}")
+   target_link_libraries(qt_with_dip DIP Qt6::Widgets)
+   set_target_properties(qt_with_dip PROPERTIES AUTOMOC ON)
+
+   add_dependencies(examples
+                    qt_with_dip
+                    )
+
+endif()
 
 ### ---
 

--- a/examples/external_interfaces/qt_with_dip.cpp
+++ b/examples/external_interfaces/qt_with_dip.cpp
@@ -1,0 +1,58 @@
+/*
+ * This is a simple program that demonstrates mixing Qt's QImage and DIPlib.
+ * A QImage is read from disk, mapped to a dip::Image (no copy), a DIPlib
+ * filter is applied, and the result (allocated as a QImage through the
+ * ExternalInterface, again no copy) is displayed in a Qt window.
+ */
+
+#include "dip_qimage_interface.h"
+
+#include "diplib.h"
+#include "diplib/linear.h"
+
+#include <QApplication>
+#include <QLabel>
+#include <QPixmap>
+
+int main( int argc, char** argv ) {
+   QApplication app( argc, argv );
+
+   std::string filename = ( argc > 1 ) ? argv[ 1 ] : DIP_EXAMPLES_DIR "/DIP.tif";
+
+   // Read the image with Qt, convert to a supported format if necessary
+   QImage input = QImage( QString::fromStdString( filename ) ).convertToFormat( QImage::Format_RGB888 );
+   DIP_THROW_IF( input.isNull(), "Failed reading file" );
+
+   // Map the QImage to a dip::Image, without copying
+   dip::Image input_dip = dip_qimage::QImageToDip( input );
+   DIP_ASSERT( input_dip.Origin() == input.bits() ); // Verify pointers match
+
+   // Have DIPlib allocate the output as a QImage through the ExternalInterface
+   dip_qimage::ExternalInterface qtei;
+   dip::Image output_dip = qtei.NewImage();
+   DIP_ASSERT( !output_dip.IsForged() ); // Verify image is not forged -- there is no data segment yet
+
+   // Call a DIPlib function; Gauss needs a floating-point type, so we convert first
+   dip::Image tmp = dip::Convert( input_dip, dip::DT_SFLOAT );
+   dip::Gauss( tmp, tmp, { 3.0 } );
+   dip::Convert( tmp, output_dip, dip::DT_UINT8 );
+   DIP_ASSERT( output_dip.IsForged() ); // Verify image is now forged
+
+   // Get the QImage back, no copy
+   QImage output = qtei.GetQImage( output_dip );
+   DIP_ASSERT( output_dip.Origin() == output.bits() ); // Verify pointers match
+
+   // Display input and output
+   QLabel inputLabel;
+   inputLabel.setPixmap( QPixmap::fromImage( input ) );
+   inputLabel.setWindowTitle( "input" );
+   inputLabel.show();
+
+   QLabel outputLabel;
+   outputLabel.setPixmap( QPixmap::fromImage( output ) );
+   outputLabel.setWindowTitle( "output (Gaussian blurred)" );
+   outputLabel.move( inputLabel.x() + inputLabel.width() + 20, inputLabel.y() );
+   outputLabel.show();
+
+   return app.exec();
+}

--- a/include/dip_qimage_interface.h
+++ b/include/dip_qimage_interface.h
@@ -1,0 +1,228 @@
+/*
+ * (c)2026, Tolga Ciftcicelik.
+ * Based on dip_opencv_interface.h: (c)2018-2021, Flagship Biosciences. Written by Cris Luengo.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#ifndef DIP_QIMAGE_INTERFACE_H
+#define DIP_QIMAGE_INTERFACE_H
+
+#include <map>
+
+#include "diplib.h"
+
+#include <QImage>
+
+
+/// \file
+/// \brief This file defines the \ref dip_qimage namespace, functionality to interface *Qt*'s `QImage` and *DIPlib*.
+
+
+/// \group dip_qimage_interface *DIPlib*-*Qt* interface
+/// \ingroup interfaces
+/// \brief Functions to convert images to and from *Qt*'s `QImage`.
+///
+/// The \ref dip_qimage namespace defines the functions needed to convert between *Qt* `QImage` objects and *DIPlib*
+/// \ref dip::Image objects.
+///
+/// We define a class \ref dip_qimage::ExternalInterface so that output images from *DIPlib* can yield a `QImage`,
+/// for example to display the result of a processing pipeline in a *Qt* UI. The function \ref dip_qimage::QImageToDip
+/// encapsulates (maps) a `QImage` in a *DIPlib* image; there currently is no copyless way to go the other direction
+/// for an arbitrary \ref dip::Image, see \ref dip_qimage::ExternalInterface instead.
+///
+/// \section dip_qimage_limitations Limitations
+///
+/// `QImage` is much more limited in how the pixel data is stored than a \ref dip::Image, and consequently only a
+/// small subset of *DIPlib* images can be mapped to (or from) a `QImage`. These are the limitations:
+///
+/// - Only 8-bit unsigned integer samples (\ref dip::DT_UINT8) are supported, because these are the only depth that
+///   `QImage` natively supports for the formats we use. If your image has any other data type, convert it first,
+///   for example with \ref dip::Convert. Note that this conversion clips or truncates values, it does not rescale
+///   them: an image with a wider range (e.g. 16-bit unsigned data read from a PNG or TIFF file) must be scaled to
+///   the 0-255 range before conversion, or the result will be clipped to white.
+///
+/// - Only 1 (grayscale), 3 (RGB) or 4 (RGBA) channels are supported, mapping to `QImage::Format_Grayscale8`,
+///   `QImage::Format_RGB888` and `QImage::Format_RGBA8888`, respectively. The tensor stride must be 1 (interleaved
+///   channels), matching *DIPlib*'s default.
+///
+/// - Only 2D images can be mapped.
+///
+/// !!! attention
+///     When a \ref dip::Image reads a file with an alpha channel, the alpha channel is the last tensor element
+///     (2nd or 4th), matching the channel order expected by `QImage::Format_RGBA8888`. No channel reordering is
+///     needed.
+/// \addtogroup
+
+
+/// \brief The `dip_qimage` namespace contains the interface between *Qt*'s `QImage` and *DIPlib*.
+namespace dip_qimage {
+
+
+namespace detail {
+
+inline QImage::Format GetQImageFormat( dip::uint channels ) {
+   switch( channels ) {
+      case 1: return QImage::Format_Grayscale8;
+      case 3: return QImage::Format_RGB888;
+      case 4: return QImage::Format_RGBA8888;
+      default: DIP_THROW( "QImage interface only supports 1 (gray), 3 (RGB) or 4 (RGBA) channels" );
+   }
+}
+
+} // namespace detail
+
+
+/// \brief Creates a *DIPlib* image around a *Qt* `QImage`, without taking ownership of the data.
+///
+/// This function maps a `QImage` object to a \ref dip::Image object. The `dip::Image` object will point to the
+/// data in the `QImage`, which must continue existing until the `dip::Image` is deleted or stripped. The output
+/// \ref dip::Image is protected to prevent accidental reforging, unprotect it using \ref dip::Image::Protect.
+///
+/// `img` must be in one of the formats `QImage::Format_Grayscale8`, `QImage::Format_RGB888` or
+/// `QImage::Format_RGBA8888`; convert `img` first (e.g. with `QImage::convertToFormat`) if it isn't. An empty
+/// `QImage` produces a non-forged \ref dip::Image.
+///
+/// Note that `QImage::bits()` is non-const and detaches the `QImage` from any shared (implicitly copied) data,
+/// this function calls it on a `const&`, requiring a `const_cast`; be aware that this can trigger a deep copy
+/// inside `QImage` itself if its data was shared with another `QImage` object.
+inline dip::Image QImageToDip( QImage const& img ) {
+   if( img.isNull() ) {
+      return {};
+   }
+   dip::uint channels;
+   switch( img.format() ) {
+      case QImage::Format_Grayscale8: channels = 1; break;
+      case QImage::Format_RGB888: channels = 3; break;
+      case QImage::Format_RGBA8888: channels = 4; break;
+      default: DIP_THROW( "Unsupported QImage format, convert to Grayscale8, RGB888 or RGBA8888 first" );
+   }
+   dip::UnsignedArray sizes = { static_cast< dip::uint >( img.width() ), static_cast< dip::uint >( img.height() ) };
+   dip::Tensor tensor( channels );
+   // QImage's scanlines are `bytesPerLine()` bytes long, which can include padding for alignment; since our
+   // sample type is always 1 byte (UINT8), this is directly the y-stride, in samples.
+   dip::IntegerArray strides = {
+         static_cast< dip::sint >( channels ),
+         static_cast< dip::sint >( img.bytesPerLine() )
+   };
+   dip::sint tensorStride = 1;
+   uchar* data = const_cast< uchar* >( img.bits() );
+   dip::Image out( dip::NonOwnedRefToDataSegment( data ), data, dip::DT_UINT8, sizes, strides, tensor, tensorStride );
+   out.Protect();
+   return out;
+}
+
+
+/// \brief This class is the \ref dip::ExternalInterface for the *Qt* interface.
+///
+/// Use the following code when declaring images to be used as the output to a *DIPlib* function:
+///
+/// ```cpp
+/// dip_qimage::ExternalInterface qtei;
+/// dip::Image img_out = qtei.NewImage();
+/// ```
+///
+/// This configures the image `img_out` such that, when it is forged later on, a `QImage` object will be created
+/// to hold the pixel data. Only images with 1, 3 or 4 channels of type \ref dip::DT_UINT8 can be forged this way,
+/// see \ref dip_qimage_limitations for details. For other images, the allocator will fail, prompting *DIPlib* to
+/// use its own, default allocator instead. The resulting \ref dip::Image object cannot be converted to a `QImage`.
+///
+/// The \ref dip::ExternalInterface object owns the `QImage` objects. You need to keep it around as long as you use
+/// the image objects returned by its \ref NewImage method, otherwise the data segments will be freed and the
+/// \ref dip::Image objects will point to non-existing data segments.
+///
+/// To retrieve the `QImage` object inside such a \ref dip::Image, use the \ref GetQImage method:
+///
+/// ```cpp
+/// QImage img = qtei.GetQImage( img_out );
+/// ```
+///
+/// Remember to not assign a result into the image created with \ref NewImage, as the pixel data will be copied in
+/// the assignment. Instead, use the *DIPlib* functions that take output images as function arguments:
+///
+/// ```cpp
+/// img_out = in1 + in2;           // Bad! Incurs an unnecessary copy
+/// dip::Add( in1, in2, img_out ); // Correct, the operation writes directly in the output data segment
+/// ```
+class ExternalInterface : public dip::ExternalInterface {
+   private:
+      // This map holds `QImage`s, we can find the right one if we have the data pointer.
+      std::map< void const*, QImage > images_;
+
+      class StripHandler {
+         private:
+            ExternalInterface& interface_;
+         public:
+            explicit StripHandler( ExternalInterface& ei ) : interface_( ei ) {}
+            void operator()( void const* p ) const { interface_.images_.erase( p ); }
+      };
+
+   public:
+      // This function overrides `dip::ExternalInterface::AllocateData`. It is called when an image with this
+      // `ExternalInterface` is forged. It allocates a `QImage` and returns a `dip::DataSegment` to the data
+      // pointer, with a custom deleter functor.
+      //
+      // A user will never call this function directly.
+      dip::DataSegment AllocateData(
+            void*& origin,
+            dip::DataType datatype,
+            dip::UnsignedArray const& sizes,
+            dip::IntegerArray& strides,
+            dip::Tensor const& tensor,
+            dip::sint& tensorStride
+      ) override {
+         DIP_THROW_IF( datatype != dip::DT_UINT8, "QImage interface only supports UINT8 images" );
+         DIP_THROW_IF( sizes.size() != 2, "QImage interface only supports 2D images" );
+         dip::uint channels = tensor.Elements();
+         QImage::Format format;
+         DIP_STACK_TRACE_THIS( format = detail::GetQImageFormat( channels ) );
+         QImage img( static_cast< int >( sizes[ 0 ] ), static_cast< int >( sizes[ 1 ] ), format );
+         origin = img.bits();
+         strides.resize( 2 );
+         strides[ 0 ] = static_cast< dip::sint >( channels );
+         strides[ 1 ] = static_cast< dip::sint >( img.bytesPerLine() );
+         tensorStride = 1;
+         images_.emplace( origin, std::move( img ) );
+         return dip::DataSegment{ origin, StripHandler( *this ) };
+      }
+
+      /// \brief Returns the `QImage` that holds the data for the \ref dip::Image `img`.
+      ///
+      /// The `QImage` returned is the one allocated to hold the pixel data in the input `img`. If `img` is a view
+      /// of another image, or has been manipulated such that it no longer matches the `QImage` it was allocated
+      /// in, this function throws an exception; use \ref dip::Image::ForceNormalStrides beforehand if needed.
+      QImage GetQImage( dip::Image const& img ) {
+         DIP_THROW_IF( !img.IsForged(), dip::E::IMAGE_NOT_FORGED );
+         auto it = images_.find( img.Data() );
+         DIP_THROW_IF( it == images_.end(), "Image was not allocated by this interface" );
+         QImage out = std::move( it->second );
+         images_.erase( it );
+         return out;
+      }
+
+      /// \brief Constructs a \ref dip::Image object with the external interface set so that, when forged, a
+      /// `QImage` will be allocated to hold the samples.
+      dip::Image NewImage() {
+         dip::Image out;
+         out.SetExternalInterface( this );
+         return out;
+      }
+};
+
+
+/// \endgroup
+
+} // namespace dip_qimage
+
+#endif // DIP_QIMAGE_INTERFACE_H


### PR DESCRIPTION
## Summary

Adds `dip_qimage_interface.h`, a header-only interface (following the same
pattern as `dip_opencv_interface.h` and `dip_vigra_interface.h`) that maps
`QImage` objects to/from `dip::Image` objects without copying pixel data.

Closes #218.

Two pieces, both in the `dip_qimage` namespace:

- `QImageToDip(QImage const&)` — wraps an existing `QImage` as a `dip::Image`
  pointing at the same memory (input direction).
- `dip_qimage::ExternalInterface` — a `dip::ExternalInterface` that, when
  attached to an output image via `NewImage()`, allocates a `QImage` instead
  of DIPlib's default buffer when the image is forged. `GetQImage()` then
  retrieves that `QImage`, still pointing at the same data DIPlib wrote to.
  This is the piece hinted at in the issue discussion.

Following the hints in the issue: stride/padding is handled by reading
`QImage::bytesPerLine()` directly rather than assuming a fixed
`width * channels`, since Qt pads scanlines for alignment on some formats.

## Supported formats

Only `dip::DT_UINT8` images, with 1 (`Format_Grayscale8`), 3
(`Format_RGB888`) or 4 (`Format_RGBA8888`) channels — this is a `QImage`
limitation, not a `dip::Image` one. When a `dip::Image` has alpha as its
last tensor element (as `dip::ImageRead` produces for images with an alpha
channel), the channel order already matches `Format_RGBA8888`, no
reordering needed.

Converting a wider data type (e.g. 16-bit PNG/TIFF) must be scaled to the
0-255 range by the caller before use; `dip::Convert` clips rather than
rescales, this is documented in the header (`\attention` note) since it's
an easy trap (I hit it myself while testing).

## Files changed

- `include/dip_qimage_interface.h` (new) — the interface implementation.
- `examples/external_interfaces/qt_with_dip.cpp` (new) — usage example:
  reads an image with `QImage`, maps it with `QImageToDip`, runs
  `dip::Gauss` writing into an `ExternalInterface`-allocated output, and
  displays both with Qt widgets. Mirrors the OpenCV/Vigra examples.
- `examples/CMakeLists.txt` — builds the new example, guarded by
  `find_package(Qt6 QUIET COMPONENTS Widgets)`, same pattern as the
  OpenCV/Vigra blocks.
- `doc/src/main.md` — added Qt to the interfaces list.

