### PR TITLE
Centroid diameter polygon refactor

### DIFF
--- a/include/diplib/polygon.h
+++ b/include/diplib/polygon.h
@@ -422,6 +422,14 @@ struct DIP_NO_EXPORT FeretValues {
    dfloat minAngle = 0.0;           ///< The angle at which `minDiameter` was measured
 };
 
+/// \brief Holds the two output values of the \ref dip::Polygon::CentroidDiameter function.
+struct DIP_NO_EXPORT CentroidDiameterValues {
+   dfloat maxDiameter = 0.0;   ///< The maximum diameter through the centroid
+   dfloat minDiameter = 0.0;   ///< The minimum diameter through the centroid
+   dfloat maxAngle = 0.0;      ///< The angle at which `maxDiameter` was measured
+   dfloat minAngle = 0.0;      ///< The angle at which `minDiameter` was measured
+};
+
 /// \brief Holds the various output values of the \ref dip::Polygon::RadiusStatistics function.
 class DIP_NO_EXPORT RadiusValues {
    public:
@@ -661,6 +669,19 @@ struct DIP_NO_EXPORT Polygon {
    /// \brief Returns statistics on the radii of the polygon. The radii are the distances between the given centroid
    /// and each of the vertices.
    DIP_EXPORT RadiusValues RadiusStatistics( VertexFloat const& g ) const;
+
+   /// \brief Returns the maximum and minimum diameters through the centroid. For each vertex, the diameter is
+   /// the sum of its distance to the centroid and the (linearly interpolated) distance to the centroid of the
+   /// point directly opposite it, at the same angle plus &pi;. The angle at which each extreme was found is
+   /// also returned.
+   CentroidDiameterValues CentroidDiameter() const {
+      VertexFloat g = Centroid();
+      return CentroidDiameter( g );
+   }
+
+   /// \brief Returns the maximum and minimum diameters through the given centroid. See the other overload for
+   /// details.
+   DIP_EXPORT CentroidDiameterValues CentroidDiameter( VertexFloat const& g ) const;
 
    /// \brief Compares a polygon to the ellipse with the same covariance matrix, returning the coefficient of
    /// variation of the distance of vertices to the ellipse.

--- a/src/measurement/feature_centroid_diameter.h
+++ b/src/measurement/feature_centroid_diameter.h
@@ -38,79 +38,11 @@ class FeatureCentroidDiameter : public PolygonBased {
       }
 
       void Measure( Polygon const& polygon, Measurement::ValueIterator output ) override {
-         struct Sample {
-            dfloat angle{};
-            dfloat radius{};
-         };
-         VertexFloat centroid = polygon.Centroid();
-         std::vector< Sample > samples;
-         samples.reserve( polygon.vertices.size() );
-         for( auto const& v : polygon.vertices ) {
-            dfloat dx = v.x - centroid.x;
-            dfloat dy = v.y - centroid.y;
-            samples.push_back( { std::atan2( dy, dx ), std::hypot( dx, dy ) } );
-         }
-         if( samples.size() < 2 ) {
-            // Degenerate polygon, not enough vertices to compute a meaningful diameter.
-            output[ 0 ] = 0;
-            output[ 1 ] = 0;
-            output[ 2 ] = 0;
-            output[ 3 ] = 0;
-            return;
-         }
-         std::sort( samples.begin(), samples.end(), []( Sample const& a, Sample const& b ) {
-            return a.angle < b.angle;
-         } );
-         dip::uint n = samples.size();
-
-         // Linearly interpolates the object's radius at an arbitrary angle, between the two
-         // nearest samples. The polygon typically has one vertex per boundary pixel, so this
-         // interpolation error is sub-pixel.
-         auto radiusAt = [ & ]( dfloat angle ) {
-            while( angle < -pi ) {
-               angle += 2.0 * pi;
-            }
-            while( angle >= pi ) {
-               angle -= 2.0 * pi;
-            }
-            dip::uint idx = static_cast< dip::uint >( std::lower_bound( samples.begin(), samples.end(), angle,
-                  []( Sample const& s, dfloat a ) { return s.angle < a; } ) - samples.begin() );
-            dip::uint i0 = ( idx == 0 ) ? ( n - 1 ) : ( idx - 1 );
-            dip::uint i1 = idx % n;
-            dfloat a0 = samples[ i0 ].angle;
-            dfloat a1 = samples[ i1 ].angle;
-            dfloat da = a1 - a0;
-            if( da < 0 ) {
-               da += 2.0 * pi;
-            }
-            dfloat t = angle - a0;
-            if( t < 0 ) {
-               t += 2.0 * pi;
-            }
-            t = ( da < 1e-9 ) ? 0.0 : ( t / da );
-            return samples[ i0 ].radius + t * ( samples[ i1 ].radius - samples[ i0 ].radius );
-         };
-
-         dfloat diameterMin = std::numeric_limits< dfloat >::max();
-         dfloat diameterMax = 0;
-         dfloat minAngle = 0;
-         dfloat maxAngle = 0;
-         for( auto const& s : samples ) {
-            dfloat diameter = s.radius + radiusAt( s.angle + pi );
-            if( diameter < diameterMin ) {
-               diameterMin = diameter;
-               minAngle = s.angle;
-            }
-            if( diameter > diameterMax ) {
-               diameterMax = diameter;
-               maxAngle = s.angle;
-            }
-         }
-
-         output[ 0 ] = diameterMax * scale_;
-         output[ 1 ] = diameterMin * scale_;
-         output[ 2 ] = maxAngle;
-         output[ 3 ] = minAngle;
+         CentroidDiameterValues cd = polygon.CentroidDiameter();
+         output[ 0 ] = cd.maxDiameter * scale_;
+         output[ 1 ] = cd.minDiameter * scale_;
+         output[ 2 ] = cd.maxAngle;
+         output[ 3 ] = cd.minAngle;
       }
 
    private:

--- a/src/measurement/measure_polygon.cpp
+++ b/src/measurement/measure_polygon.cpp
@@ -135,6 +135,71 @@ RadiusValues Polygon::RadiusStatistics( VertexFloat const& g ) const {
    return radius;
 }
 
+CentroidDiameterValues Polygon::CentroidDiameter( VertexFloat const& g ) const {
+   struct Sample {
+      dfloat angle{};
+      dfloat radius{};
+   };
+   std::vector< Sample > samples;
+   samples.reserve( vertices.size() );
+   for( auto const& v : vertices ) {
+      dfloat dx = v.x - g.x;
+      dfloat dy = v.y - g.y;
+      samples.push_back( { std::atan2( dy, dx ), std::hypot( dx, dy ) } );
+   }
+   CentroidDiameterValues out;
+   if( samples.size() < 2 ) {
+      return out; // Degenerate polygon, not enough vertices to compute a meaningful diameter.
+   }
+   std::sort( samples.begin(), samples.end(), []( Sample const& a, Sample const& b ) {
+      return a.angle < b.angle;
+   } );
+   dip::uint n = samples.size();
+
+   // Linearly interpolates the object's radius at an arbitrary angle, between the two nearest samples.
+   auto radiusAt = [ & ]( dfloat angle ) {
+      while( angle < -pi ) {
+         angle += 2.0 * pi;
+      }
+      while( angle >= pi ) {
+         angle -= 2.0 * pi;
+      }
+      dip::uint idx = static_cast< dip::uint >( std::lower_bound( samples.begin(), samples.end(), angle,
+            []( Sample const& s, dfloat a ) { return s.angle < a; } ) - samples.begin() );
+      dip::uint i0 = ( idx == 0 ) ? ( n - 1 ) : ( idx - 1 );
+      dip::uint i1 = idx % n;
+      dfloat a0 = samples[ i0 ].angle;
+      dfloat a1 = samples[ i1 ].angle;
+      dfloat da = a1 - a0;
+      if( da < 0 ) {
+         da += 2.0 * pi;
+      }
+      dfloat t = angle - a0;
+      if( t < 0 ) {
+         t += 2.0 * pi;
+      }
+      t = ( da < 1e-9 ) ? 0.0 : ( t / da );
+      return samples[ i0 ].radius + t * ( samples[ i1 ].radius - samples[ i0 ].radius );
+   };
+
+   dfloat diameterMin = std::numeric_limits< dfloat >::max();
+   dfloat diameterMax = 0;
+   for( auto const& s : samples ) {
+      dfloat diameter = s.radius + radiusAt( s.angle + pi );
+      if( diameter < diameterMin ) {
+         diameterMin = diameter;
+         out.minAngle = s.angle;
+      }
+      if( diameter > diameterMax ) {
+         diameterMax = diameter;
+         out.maxAngle = s.angle;
+      }
+   }
+   out.maxDiameter = diameterMax;
+   out.minDiameter = diameterMin;
+   return out;
+}
+
 dfloat Polygon::EllipseVariance( VertexFloat const& g, dip::CovarianceMatrix const& C ) const {
    // Inverse of covariance matrix
    dip::CovarianceMatrix U = C.Inv();


### PR DESCRIPTION
Moves FeatureCentroidDiameter's computation into Polygon::CentroidDiameter(),
mirroring the existing RadiusStatistics() pattern (no-arg convenience 
overload + explicit-centroid version), per the suggestion in #234.

New: dip::CentroidDiameterValues struct, dip::Polygon::CentroidDiameter().
FeatureCentroidDiameter::Measure() now just calls the new method.

Verified: identical output before/after the refactor on a real backlit 
image (donut/washer shape), both rough and subpixel-refined polygons.